### PR TITLE
Get the LS to work on a Mac

### DIFF
--- a/lib/mushy/fluxs/ls.rb
+++ b/lib/mushy/fluxs/ls.rb
@@ -2,6 +2,16 @@ module Mushy
 
   class Ls < Bash
 
+    def self.the_ls_command
+      if @the_ls_command.nil? # find out which ls command we should use
+        options = ['ls', 'gls'] # usually we should use ls, but BSD might need gls after (brew install coreutils)
+        while @the_ls_command.nil? && (command = options.shift) # keep trying till we find an answer
+          @the_ls_command = command if Mushy::Bash.new.process({}, { command: "#{command} --full-time" })[:success]
+        end
+      end
+      @the_ls_command
+    end
+
     def self.details
       {
         name: 'Ls',
@@ -144,7 +154,7 @@ module Mushy
     end
 
     def build_the_command_from arguments
-      command = 'ls'
+      command = self.class.the_ls_command
       "#{command} #{arguments.join(' ')}"
     end
 

--- a/lib/mushy/fluxs/ls.rb
+++ b/lib/mushy/fluxs/ls.rb
@@ -17,7 +17,7 @@ module Mushy
       while the_command_to_use.nil? && (command = commands.shift) # keep trying till we find one that works
         the_command_to_use = command if Mushy::Bash.new.process({}, { command: "#{command} --full-time" })[:success]
       end
-      the_command_to_use
+      the_command_to_use || -1
     end
 
     def self.details
@@ -152,6 +152,8 @@ module Mushy
     end
 
     def process event, config
+      raise 'ls is not available' if self.class.the_ls_command == -1
+
       arguments = build_the_arguments_from config
 
       config[:command] = build_the_command_from arguments

--- a/lib/mushy/fluxs/ls.rb
+++ b/lib/mushy/fluxs/ls.rb
@@ -3,13 +3,21 @@ module Mushy
   class Ls < Bash
 
     def self.the_ls_command
-      if @the_ls_command.nil? # find out which ls command we should use
-        options = ['ls', 'gls'] # usually we should use ls, but BSD might need gls after (brew install coreutils)
-        while @the_ls_command.nil? && (command = options.shift) # keep trying till we find an answer
-          @the_ls_command = command if Mushy::Bash.new.process({}, { command: "#{command} --full-time" })[:success]
-        end
+      @the_ls_command ||= find_the_right_ls_command_to_use
+    end
+
+    def self.find_the_right_ls_command_to_use
+      commands = [
+        'ls', # the normal method used to pull file information
+        'gls' # BSD users don't get the version of ls this needs,
+              # so we might need to use gls after the user runs (brew install coreutils)
+      ]
+
+      the_command_to_use = nil
+      while the_command_to_use.nil? && (command = commands.shift) # keep trying till we find one that works
+        the_command_to_use = command if Mushy::Bash.new.process({}, { command: "#{command} --full-time" })[:success]
       end
-      @the_ls_command
+      the_command_to_use
     end
 
     def self.details

--- a/lib/mushy/fluxs/ls.rb
+++ b/lib/mushy/fluxs/ls.rb
@@ -144,7 +144,8 @@ module Mushy
     end
 
     def build_the_command_from arguments
-      "ls #{arguments.join(' ')}"
+      command = 'ls'
+      "#{command} #{arguments.join(' ')}"
     end
 
     def build_the_arguments_from config


### PR DESCRIPTION
I found that I had to install coreutils

```
brew install coreutils
```

in order to get a the same `ls` command I had before.  But even after installing, that command was only available as `gls`.  So now the `Ls` class will see which one it should use before executing.